### PR TITLE
减少空闲CPU占用和加快异步响应速度

### DIFF
--- a/fibjs/include/AsyncCall.h
+++ b/fibjs/include/AsyncCall.h
@@ -7,25 +7,7 @@
 namespace fibjs
 {
 
-class BlockedAsyncQueue: public exlib::AsyncQueue
-{
-public:
-    void put(exlib::AsyncEvent *o)
-    {
-        exlib::AsyncQueue::put(o);
-        m_sem.Post();
-    }
-
-    exlib::AsyncEvent *wait()
-    {
-        m_sem.Wait();
-        return exlib::AsyncQueue::get();
-    }
-
-private:
-    exlib::OSSemaphore m_sem;
-};
-
+typedef exlib::AsyncQueue BlockedAsyncQueue;
 extern BlockedAsyncQueue s_acPool;
 
 class AsyncCall: public asyncEvent


### PR DESCRIPTION
修改lockfree模板类,
优先使用无锁变量检查是否有线程在等待信号, 实现在高负载时不会进入到操作系统锁流程, 拥有原先无锁的优势
在程序完全空闲后, 进入操作系统锁状态, 挂起当前线程, 实现0系统CPU资源占用.