### PR TITLE
Update mongo.c

### DIFF
--- a/vender/mongo/src/mongo.c
+++ b/vender/mongo/src/mongo.c
@@ -19,7 +19,7 @@
   #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#if _MSC_VER
+#if _MSC_VER < 1900
   #define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
解决mongo在vs2005中编译发生snprintf重定义错误