### PR TITLE
修复console.timeEnd方法整形溢出问题

### DIFF
--- a/fibjs/src/console/console.cpp
+++ b/fibjs/src/console/console.cpp
@@ -200,7 +200,7 @@ result_t console_base::time(exlib::string label)
 
 result_t console_base::timeEnd(exlib::string label)
 {
-    long t = (long) (Ticks() - s_timers[label]);
+    int64_t t = (int64_t) (Ticks() - s_timers[label]);
 
     s_timers.erase(label);
 

--- a/fibjs/src/console/console.cpp
+++ b/fibjs/src/console/console.cpp
@@ -200,7 +200,7 @@ result_t console_base::time(exlib::string label)
 
 result_t console_base::timeEnd(exlib::string label)
 {
-    int64_t t = (int64_t) (Ticks() - s_timers[label]);
+    int64_t t = Ticks() - s_timers[label];
 
     s_timers.erase(label);
 


### PR DESCRIPTION
修复console.timeEnd方法整形溢出问题