### PR TITLE
fix:Added explicit casts to `CGEventFlags`.

### DIFF
--- a/fibjs/src/console/osx/console_key.cpp
+++ b/fibjs/src/console/osx/console_key.cpp
@@ -386,7 +386,7 @@ void toggleKeyCode(int32_t code, const bool down, int32_t flags)
 		assert(keyEvent != NULL);
 
 		CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
-		CGEventSetFlags(keyEvent, flags);
+		CGEventSetFlags(keyEvent, CGEventFlags(flags));
 		CGEventPost(kCGSessionEventTap, keyEvent);
 		CFRelease(keyEvent);
 	}


### PR DESCRIPTION
修复Mac OSX 10.11 编译错误